### PR TITLE
Remove type check for secret, fixes #9

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,10 +40,6 @@ export default function init (options = {}) {
       throw new Error(`You must provide a 'header' in your authentication configuration or pass one explicitly`);
     }
 
-    if (typeof jwtSettings.secret !== 'string') {
-      throw new Error(`You must provide a 'secret' in your authentication configuration or pass one explicitly`);
-    }
-
     let Verifier = DefaultVerifier;
     let strategyOptions = merge({
       secretOrKey: jwtSettings.secret,


### PR DESCRIPTION
This is to support `Buffer` like `jsonwebtoken` itself does.